### PR TITLE
Infer checking granularity based on available comments

### DIFF
--- a/crates/sniff-test/src/annotations/mod.rs
+++ b/crates/sniff-test/src/annotations/mod.rs
@@ -126,7 +126,7 @@ impl ExpressionAnnotation {
             .iter()
             .filter(|condition| {
                 assert!(
-                    ARGS.lock().unwrap().as_ref().unwrap().buzzword_checking,
+                    ARGS.0.lock().unwrap().as_ref().unwrap().buzzword_checking,
                     "not sure how to check properly yet."
                 );
                 !buzzword_satisfied(&text_lower, &condition.node.name)
@@ -203,14 +203,15 @@ impl DefAnnotation {
     /// Whether this function's annotation creates an obligation that it's callers must uphold.
     pub fn creates_obligation(&self) -> Option<Obligation> {
         match &self.local_violation_annotation {
-            PropertyViolation::Conditionally(conditions)
-                if ARGS.lock().unwrap().as_ref().unwrap().fine_grained =>
-            {
-                Some(Obligation::ConsiderConditions(conditions.clone()))
+            PropertyViolation::Conditionally(conditions) => {
+                if ARGS.peep().granularity.force_coarse() {
+                    // If we're forcing coarse, just create a coarse-grained obligation
+                    Some(Obligation::ConsiderProperty)
+                } else {
+                    Some(Obligation::ConsiderConditions(conditions.clone()))
+                }
             }
-            PropertyViolation::Unconditional | PropertyViolation::Conditionally(_) => {
-                Some(Obligation::ConsiderProperty)
-            }
+            PropertyViolation::Unconditional => Some(Obligation::ConsiderProperty),
             PropertyViolation::Never => None,
         }
     }

--- a/crates/sniff-test/src/annotations/new_parsing.rs
+++ b/crates/sniff-test/src/annotations/new_parsing.rs
@@ -22,8 +22,11 @@ pub fn violation_from_text(
         }
         Ok(None) => {
             log::debug!("couldn't determine conditional property violation for {def_id:?}");
-            if (def_id.is_local() || ARGS.lock().unwrap().as_ref().unwrap().check_dependencies)
-                && ARGS.lock().unwrap().as_ref().unwrap().fine_grained
+
+            // If we're checking this function's crate and forcing fine-grained checking, but couldn't find
+            // the fine-grained conditions, report an error.
+            if (def_id.is_local() || ARGS.peep().check_dependencies)
+                && ARGS.peep().granularity.force_fine()
             {
                 let msg = format!(
                     "couldn't determine conditional property violation for {def_id:?} from {source:?} based on text {text:?}",
@@ -41,8 +44,8 @@ pub fn violation_from_text(
         Err(err_msg) => {
             // Only show errors in the current crate and if we're fine-grained.
             // Otherwise, malformed sniff-test conditions are just interpreted as general violation.
-            if (def_id.is_local() || ARGS.lock().unwrap().as_ref().unwrap().check_dependencies)
-                && ARGS.lock().unwrap().as_ref().unwrap().fine_grained
+            if (def_id.is_local() || ARGS.peep().check_dependencies)
+                && ARGS.peep().granularity.force_fine()
             {
                 let msg = format!(
                     "malformed conditional property violation for {def_id:?} from {source:?}: {err_msg}",

--- a/crates/sniff-test/src/lib.rs
+++ b/crates/sniff-test/src/lib.rs
@@ -50,30 +50,45 @@ pub struct PrintAllItemsPlugin;
 
 // To parse CLI arguments, we use Clap for this example. But that
 // detail is up to you.
-#[derive(Parser, Serialize, Deserialize, Default, Clone, Debug)]
+#[derive(Parser, Serialize, Deserialize, Clone, Debug)]
 pub struct SniffTestArgs {
     /// How to handle this workspace's dependencies.
     #[arg(short, long)]
     dependencies: DependenciesPosture,
 
     #[arg(short, long)]
-    /// LEGACY ARG (i'm keeping it around to be faster, will remove later):
+    /// TODO: LEGACY ARG (i'm keeping it around to be faster, will remove later):
     /// whether or not dependencies have to have sniff-test formatted code comments.
     check_dependencies: bool,
 
-    #[arg(short, long)]
-    fine_grained: bool,
+    #[arg(short, long, default_value = "inferred")]
+    /// The granularity at which to check properties.
+    ///
+    /// Fine-grained will enforce that a given set of obligations has been considered at each call site for each property.
+    /// Coarse-grained will simply enforce that the property has been considered at each call site.
+    granularity: CheckingGranularity,
 
-    #[arg(short, long)]
+    #[arg(short, long, default_value = "true")]
     buzzword_checking: bool,
 
     #[clap(last = true)]
     cargo_args: Vec<String>,
 }
 
-#[derive(ValueEnum, Clone, Debug, Default, Serialize, Deserialize)]
+impl SniffTestArgs {
+    pub fn rustc_testing_default() -> Self {
+        Self {
+            dependencies: DependenciesPosture::Trust,
+            check_dependencies: false,
+            granularity: CheckingGranularity::Inferred,
+            buzzword_checking: true,
+            cargo_args: vec![],
+        }
+    }
+}
+
+#[derive(ValueEnum, Clone, Debug, Serialize, Deserialize)]
 enum DependenciesPosture {
-    #[default]
     /// Trust that dependencies have been properly documented with regard to the desired properties.
     ///
     /// *"I trust them"*
@@ -90,9 +105,45 @@ enum DependenciesPosture {
     Verify,
 }
 
+#[derive(ValueEnum, Clone, Debug, Serialize, Deserialize)]
+enum CheckingGranularity {
+    /// Force fine-grained checking.
+    ///
+    /// This will result in errors if function definitions don't have fine-grained, sniff-test style doc comments.
+    ForceFine,
+    /// Infer the desired granularity for each function.
+    ///
+    /// If the function's definition has fine-grained obligations in its doc comment, will use fine-grained. If not,
+    /// will use coarse-grained.
+    Inferred,
+    /// Force coarse-grained checking.
+    ///
+    /// This will ignore the named obligations of any fine-grained, sniff-test style doc comments.
+    ForceCoarse,
+}
+
+impl CheckingGranularity {
+    pub fn force_coarse(&self) -> bool {
+        matches!(self, Self::ForceCoarse)
+    }
+
+    /// Whether fine-grained
+    pub fn force_fine(&self) -> bool {
+        matches!(self, Self::ForceFine)
+    }
+}
+
 const TO_FILE: bool = false;
 
-pub static ARGS: Mutex<Option<SniffTestArgs>> = Mutex::new(None);
+pub struct ArgsWrapper(Mutex<Option<SniffTestArgs>>);
+
+impl ArgsWrapper {
+    pub fn peep(&self) -> SniffTestArgs {
+        self.0.lock().unwrap().as_ref().unwrap().clone()
+    }
+}
+
+pub static ARGS: ArgsWrapper = ArgsWrapper(Mutex::new(None));
 
 fn env_logger_init_file(driver: bool) {
     use std::fs::OpenOptions;
@@ -182,7 +233,7 @@ impl RustcPlugin for PrintAllItemsPlugin {
         plugin_args: Self::Args,
     ) -> rustc_interface::interface::Result<()> {
         // Set the args so we can access them from anywhere...
-        *ARGS.lock().unwrap() = Some(plugin_args.clone());
+        *ARGS.0.lock().unwrap() = Some(plugin_args.clone());
 
         let mut callbacks = PrintAllItemsCallbacks {
             args: Some(plugin_args.clone()),

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -253,7 +253,7 @@ fn rustc_sniff(file_path: &Path) -> anyhow::Result<SniffTestOutput> {
     // We have to serialize the default plugin args so it knows what to do.
     cmd.env(
         "PLUGIN_ARGS",
-        serde_json::to_string(&sniff_test::SniffTestArgs::default())
+        serde_json::to_string(&sniff_test::SniffTestArgs::rustc_testing_default())
             .expect("default args should be serializeable"),
     );
 

--- a/tests/toml/pass_external/sniff-test.toml
+++ b/tests/toml/pass_external/sniff-test.toml
@@ -1,5 +1,5 @@
 ["std::thread::sleep"]
 requirements = """
 # Safety
-* 'non-blocking': Function must not be called in a routine which cannot block.
+* non-blocking: Function must not be called in a routine which cannot block.
 """


### PR DESCRIPTION
Infers the granularity of checking based on comments existing in the code.

If a function's definition has fine-grained, sniff-test style comments, our analysis will do a fine-grained check for that function and, if not, we'll default to coarse-grained. This also introduces options for forcing one of the two behaviors across a codebase.