### PR TITLE
Run analysis with just the right amount of code optimizations

### DIFF
--- a/crates/sniff-test/src/lib.rs
+++ b/crates/sniff-test/src/lib.rs
@@ -207,7 +207,7 @@ impl RustcPlugin for PrintAllItemsPlugin {
         let existing = std::env::var("RUSTFLAGS").unwrap_or_default();
         // TODO: is disabling all optimizations overkill? it might negate the nice thing we noticed with the
         // compiler eliding bounds checks if it knows through range analysis that one can never fail.
-        cargo.env("RUSTFLAGS", format!("-Zcrate-attr=feature(register_tool) -Zcrate-attr=register_tool(sniff_tool) -Aunused-doc-comments {existing} -Zcrate-attr=feature(custom_inner_attributes) -Zmir-opt-level=0"));
+        cargo.env("RUSTFLAGS", format!("-Zcrate-attr=feature(register_tool) -Zcrate-attr=register_tool(sniff_tool) -Aunused-doc-comments {existing} -Zcrate-attr=feature(custom_inner_attributes) -Zmir-opt-level=1"));
 
         // Point to the driver binary, not the cargo subcommand binary
         let driver = std::env::current_exe()
@@ -229,7 +229,7 @@ impl RustcPlugin for PrintAllItemsPlugin {
 
         // Add the rustc flags that cargo's --release adds if they're not already there...
         let release_flags = [
-            "opt-level=0", // except opt-level=3, as I think we want the code fully unoptimized
+            "opt-level=1", // except opt-level=3, as I think we want the code fully unoptimized
             "debug-assertions=no",
             "overflow-checks=no",
             "debuginfo=0",

--- a/crates/sniff-test/src/properties/mod.rs
+++ b/crates/sniff-test/src/properties/mod.rs
@@ -34,6 +34,7 @@ pub trait Property: Debug + Copy + 'static {
         &mut self, // TODO: why is this a mutable reference?
         tcx: TyCtxt<'tcx>,
         tyck: &TypeckResults,
+        in_body: &LocallyReachable,
         expr: &'tcx rustc_hir::Expr,
     ) -> Vec<FoundAxiom<'tcx, Self::Axiom>>;
     // TODO: why is ^this^ a Vec? conceptually feels like it could be an option,
@@ -71,10 +72,11 @@ pub struct FoundAxiom<'tcx, A: Axiom> {
     pub span: rustc_span::Span,
 }
 
-struct FinderWrapper<'tcx, T: Property> {
+struct FinderWrapper<'tcx, 'l, T: Property> {
     tcx: TyCtxt<'tcx>,
     property: T,
     tychck: &'tcx TypeckResults<'tcx>,
+    for_reachable: &'l LocallyReachable,
     axioms: Vec<FoundAxiom<'tcx, T::Axiom>>,
 }
 
@@ -90,6 +92,7 @@ pub fn find_axioms<'tcx, T: Property>(
         property,
         tychck,
         tcx,
+        for_reachable: locally_reachable,
         axioms: Vec::new(),
     };
 
@@ -98,7 +101,7 @@ pub fn find_axioms<'tcx, T: Property>(
     finder.axioms.into_iter()
 }
 
-impl<'tcx, T: Property> Visitor<'tcx> for FinderWrapper<'tcx, T> {
+impl<'tcx, T: Property> Visitor<'tcx> for FinderWrapper<'tcx, '_, T> {
     type NestedFilter = nested_filter::OnlyBodies;
     type MaybeTyCtxt = TyCtxt<'tcx>;
 
@@ -108,8 +111,12 @@ impl<'tcx, T: Property> Visitor<'tcx> for FinderWrapper<'tcx, T> {
 
     #[allow(clippy::semicolon_if_nothing_returned)]
     fn visit_expr(&mut self, ex: &'tcx rustc_hir::Expr<'tcx>) -> Self::Result {
-        self.axioms
-            .extend(self.property.find_axioms_in_expr(self.tcx, self.tychck, ex));
+        self.axioms.extend(self.property.find_axioms_in_expr(
+            self.tcx,
+            self.tychck,
+            self.for_reachable,
+            ex,
+        ));
 
         // if this expr is a closure definition, skip analyzing its body,
         // we'll do that based on the DefId of the closure itself if it was found to be reachable.

--- a/crates/sniff-test/src/properties/panic.rs
+++ b/crates/sniff-test/src/properties/panic.rs
@@ -8,6 +8,7 @@ use super::Axiom;
 use crate::{
     annotations::PropertyViolation,
     properties::{FoundAxiom, Property},
+    reachability::LocallyReachable,
 };
 
 #[derive(Debug, Clone)]
@@ -40,14 +41,27 @@ impl Property for PanicProperty {
         &mut self,
         tcx: TyCtxt<'tcx>,
         tyck: &rustc_middle::ty::TypeckResults,
+        for_reachable: &LocallyReachable,
         expr: &'tcx rustc_hir::Expr<'tcx>,
     ) -> Vec<FoundAxiom<'tcx, Self::Axiom>> {
         [
-            find_explicit_panic(tcx, expr).map(|span| FoundAxiom {
-                axiom: PanicAxiom::ExplicitPanic,
-                found_in: expr,
-                span,
-            }),
+            find_explicit_panic(tcx, expr)
+                .map(|span| FoundAxiom {
+                    axiom: PanicAxiom::ExplicitPanic,
+                    found_in: expr,
+                    span,
+                })
+                .and_then(|res| {
+                    // Only count it if our reachability determined that a call to a panic lang item
+                    // can actually happen in this function.
+                    // TODO: this is a bit of a shortcut, the real fix is to detect these base-cases at the MIR level and then
+                    // map back up, but that comes second to making the tool actually work first.
+                    if calls_panic_lang_item(tcx, for_reachable) {
+                        Some(res)
+                    } else {
+                        None
+                    }
+                }),
             find_binop(tcx, expr, rustc_ast::BinOpKind::Div).map(|span| FoundAxiom {
                 axiom: PanicAxiom::Div,
                 found_in: expr,
@@ -68,6 +82,12 @@ impl Property for PanicProperty {
         .flatten()
         .collect()
     }
+}
+
+fn calls_panic_lang_item(tcx: TyCtxt, func: &LocallyReachable) -> bool {
+    func.calls_to
+        .iter()
+        .any(|(def_id, _from_spans)| def_is_panic(tcx, *def_id))
 }
 
 fn find_binop<'tcx>(
@@ -131,18 +151,16 @@ fn find_explicit_panic<'tcx>(tcx: TyCtxt<'tcx>, expr: &'tcx rustc_hir::Expr<'tcx
         return None;
     };
 
-    let lang_items = tcx.lang_items();
-
     // Check against lang items
-    if Some(def_id) == lang_items.panic_fn()
+    def_is_panic(tcx, def_id).then_some(expr.span)
+}
+
+fn def_is_panic(tcx: TyCtxt, def_id: rustc_span::def_id::DefId) -> bool {
+    let lang_items = tcx.lang_items();
+    Some(def_id) == lang_items.panic_fn()
         || Some(def_id) == lang_items.panic_fmt()
         || Some(def_id) == lang_items.begin_panic_fn()
         || Some(def_id) == lang_items.panic_impl()
-    {
-        Some(expr.span)
-    } else {
-        None
-    }
 }
 
 impl Axiom for PanicAxiom {

--- a/crates/sniff-test/src/properties/safety.rs
+++ b/crates/sniff-test/src/properties/safety.rs
@@ -37,6 +37,9 @@ impl Property for SafetyProperty {
         &mut self,
         _tcx: TyCtxt<'tcx>,
         tyck: &rustc_middle::ty::TypeckResults,
+        // TODO: either use this to make sure the axioms actually exist, or just do some axiom checking at the
+        // MIR level.
+        _for_reachable: &LocallyReachable,
         expr: &'tcx rustc_hir::Expr<'tcx>,
     ) -> Vec<FoundAxiom<'tcx, Self::Axiom>> {
         if let ExprKind::Unary(UnOp::Deref, expr) = expr.kind {

--- a/tests/panics/opt/fail_assert.rs
+++ b/tests/panics/opt/fail_assert.rs
@@ -1,0 +1,6 @@
+extern crate sniff_test_attrs;
+
+#[sniff_test_attrs::check_panics]
+fn main() {
+    assert!(1 == 0);
+}

--- a/tests/panics/opt/fail_assert.snap
+++ b/tests/panics/opt/fail_assert.snap
@@ -1,0 +1,25 @@
+---
+source: tests/lib.rs
+assertion_line: 216
+---
+exit_code = 1
+stdout = '''
+the fail_assert crate FAILED the sniff test
+'''
+stderr = '''
+error: function main directly contains 1 unjustified panicking axiom, but is not annotated panicking
+ --> [SNIFF_TEST_DIR]/panics/opt/fail_assert.rs:4:1
+  |
+4 | fn main() {
+  | ^^^^^^^^^
+  |
+  = note: reachable from [*main*]
+note: explicit panic here
+ --> [SNIFF_TEST_DIR]/panics/opt/fail_assert.rs:5:13
+  |
+5 |     assert!(1 == 0);
+  |             ^^^^^^
+
+error: aborting due to 1 previous error
+
+'''

--- a/tests/panics/opt/fail_inlinable_call.rs
+++ b/tests/panics/opt/fail_inlinable_call.rs
@@ -1,0 +1,16 @@
+extern crate sniff_test_attrs;
+
+/// # Panics
+/// This function will panic if `count` is zero.
+fn greater_than_zero(count: usize) -> usize {
+    if count > 0 {
+        count
+    } else {
+        panic!("count should be greater than zero!");
+    }
+}
+
+#[sniff_test_attrs::check_panics]
+fn main() {
+    println!("count is {}", greater_than_zero(10));
+}

--- a/tests/panics/opt/fail_inlinable_call.snap
+++ b/tests/panics/opt/fail_inlinable_call.snap
@@ -1,0 +1,25 @@
+---
+source: tests/lib.rs
+assertion_line: 216
+---
+exit_code = 1
+stdout = '''
+the fail_inlinable_call crate FAILED the sniff test
+'''
+stderr = '''
+error: function main directly contains 1 unjustified call to annotated panicking functions, but is not annotated panicking
+  --> [SNIFF_TEST_DIR]/panics/opt/fail_inlinable_call.rs:14:1
+   |
+14 | fn main() {
+   | ^^^^^^^^^
+   |
+   = note: reachable from [*main*]
+note: greater_than_zero is called here
+  --> [SNIFF_TEST_DIR]/panics/opt/fail_inlinable_call.rs:15:29
+   |
+15 |     println!("count is {}", greater_than_zero(10));
+   |                             ^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+'''

--- a/tests/panics/opt/fail_suggest_inline_call.rs
+++ b/tests/panics/opt/fail_suggest_inline_call.rs
@@ -1,0 +1,17 @@
+extern crate sniff_test_attrs;
+
+/// # Panics
+/// This function will panic if `count` is zero.
+#[inline(always)]
+fn greater_than_zero(count: usize) -> usize {
+    if count > 0 {
+        count
+    } else {
+        panic!("count should be greater than zero!");
+    }
+}
+
+#[sniff_test_attrs::check_panics]
+fn main() {
+    println!("count is {}", greater_than_zero(10));
+}

--- a/tests/panics/opt/fail_suggest_inline_call.snap
+++ b/tests/panics/opt/fail_suggest_inline_call.snap
@@ -1,0 +1,25 @@
+---
+source: tests/lib.rs
+assertion_line: 216
+---
+exit_code = 1
+stdout = '''
+the fail_suggest_inline_call crate FAILED the sniff test
+'''
+stderr = '''
+error: function main directly contains 1 unjustified call to annotated panicking functions, but is not annotated panicking
+  --> [SNIFF_TEST_DIR]/panics/opt/fail_suggest_inline_call.rs:15:1
+   |
+15 | fn main() {
+   | ^^^^^^^^^
+   |
+   = note: reachable from [*main*]
+note: greater_than_zero is called here
+  --> [SNIFF_TEST_DIR]/panics/opt/fail_suggest_inline_call.rs:16:29
+   |
+16 |     println!("count is {}", greater_than_zero(10));
+   |                             ^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+'''

--- a/tests/panics/opt/pass_debug_assert.rs
+++ b/tests/panics/opt/pass_debug_assert.rs
@@ -1,0 +1,6 @@
+extern crate sniff_test_attrs;
+
+#[sniff_test_attrs::check_panics]
+fn main() {
+    debug_assert!(1 == 0);
+}

--- a/tests/panics/opt/pass_debug_assert.snap
+++ b/tests/panics/opt/pass_debug_assert.snap
@@ -1,0 +1,9 @@
+---
+source: tests/lib.rs
+assertion_line: 216
+---
+exit_code = 0
+stdout = '''
+the  pass_debug_assert   crate passes the sniff test!! 		(stable id [CRATE ID ELIDED]) - local
+'''
+stderr = ''

--- a/tests/panics/opt/pass_if_const_axiom.rs
+++ b/tests/panics/opt/pass_if_const_axiom.rs
@@ -1,0 +1,8 @@
+extern crate sniff_test_attrs;
+
+#[sniff_test_attrs::check_panics]
+fn main() {
+    if 1 == 0 {
+        panic!();
+    }
+}

--- a/tests/panics/opt/pass_if_const_axiom.snap
+++ b/tests/panics/opt/pass_if_const_axiom.snap
@@ -1,0 +1,9 @@
+---
+source: tests/lib.rs
+assertion_line: 216
+---
+exit_code = 0
+stdout = '''
+the pass_if_const_axiom  crate passes the sniff test!! 		(stable id [CRATE ID ELIDED]) - local
+'''
+stderr = ''

--- a/tests/panics/opt/pass_if_const_call.rs
+++ b/tests/panics/opt/pass_if_const_call.rs
@@ -1,0 +1,14 @@
+extern crate sniff_test_attrs;
+
+/// # Panics
+/// This function can panic!
+fn can_panic() {
+    panic!();
+}
+
+#[sniff_test_attrs::check_panics]
+fn main() {
+    if 1 == 0 {
+        can_panic();
+    }
+}

--- a/tests/panics/opt/pass_if_const_call.snap
+++ b/tests/panics/opt/pass_if_const_call.snap
@@ -1,0 +1,9 @@
+---
+source: tests/lib.rs
+assertion_line: 216
+---
+exit_code = 0
+stdout = '''
+the  pass_if_const_call  crate passes the sniff test!! 		(stable id [CRATE ID ELIDED]) - local
+'''
+stderr = ''

--- a/tests/panics/opt/pass_if_false_axiom.rs
+++ b/tests/panics/opt/pass_if_false_axiom.rs
@@ -1,0 +1,8 @@
+extern crate sniff_test_attrs;
+
+#[sniff_test_attrs::check_panics]
+fn main() {
+    if false {
+        panic!();
+    }
+}

--- a/tests/panics/opt/pass_if_false_axiom.snap
+++ b/tests/panics/opt/pass_if_false_axiom.snap
@@ -1,0 +1,9 @@
+---
+source: tests/lib.rs
+assertion_line: 216
+---
+exit_code = 0
+stdout = '''
+the pass_if_false_axiom  crate passes the sniff test!! 		(stable id [CRATE ID ELIDED]) - local
+'''
+stderr = ''

--- a/tests/panics/opt/pass_if_false_call.rs
+++ b/tests/panics/opt/pass_if_false_call.rs
@@ -1,0 +1,14 @@
+extern crate sniff_test_attrs;
+
+/// # Panics
+/// This function can panic!
+fn can_panic() {
+    panic!();
+}
+
+#[sniff_test_attrs::check_panics]
+fn main() {
+    if false {
+        can_panic();
+    }
+}

--- a/tests/panics/opt/pass_if_false_call.snap
+++ b/tests/panics/opt/pass_if_false_call.snap
@@ -1,0 +1,9 @@
+---
+source: tests/lib.rs
+assertion_line: 216
+---
+exit_code = 0
+stdout = '''
+the  pass_if_false_call  crate passes the sniff test!! 		(stable id [CRATE ID ELIDED]) - local
+'''
+stderr = ''


### PR DESCRIPTION
This changes the tool to use a semi-optimized version of the MIR to check whether an axiom has been eliminated by DCE and constant propagation. It also introduces tests to ensure that calls that are not truly reachable (i.e. will be immediately optimized away by the compiler) are not analyzed, but that function calls are not inlined, as this could falsely remove edges from our callgraph.

NOTE: the way this is implemented is a little jank, so, ideally, we'd swap to detecting problematic axioms at the MIR level (where optimization passes have already been run) and then map back up to the HIR to find their corresponding expression, but we currently do kind of the reverse -- finding axioms at the HIR and then checking the MIR to ignore them if they've been optimized out. I've added some TODOs in the code detailing how to fix this in the future.